### PR TITLE
githubapi: Update for GitHub Reactions API Preview change.

### DIFF
--- a/githubapi/githubapi.go
+++ b/githubapi/githubapi.go
@@ -225,7 +225,7 @@ func (s service) ListComments(ctx context.Context, rs issues.RepoSpec, id uint64
 	if err != nil {
 		return comments, err
 	}
-	reactions, err := s.reactions(ctx, issueReactions)
+	reactions, err := s.reactions(issueReactions)
 	if err != nil {
 		return comments, err
 	}
@@ -249,7 +249,7 @@ func (s service) ListComments(ctx context.Context, rs issues.RepoSpec, id uint64
 			if err != nil {
 				return comments, err
 			}
-			reactions, err := s.reactions(ctx, commentReactions)
+			reactions, err := s.reactions(commentReactions)
 			if err != nil {
 				return comments, err
 			}
@@ -449,7 +449,7 @@ func (s service) EditComment(ctx context.Context, rs issues.RepoSpec, id uint64,
 			if err != nil {
 				return issues.Comment{}, err
 			}
-			reactions, err := s.reactions(ctx, issueReactions)
+			reactions, err := s.reactions(issueReactions)
 			if err != nil {
 				return issues.Comment{}, err
 			}
@@ -498,7 +498,7 @@ func (s service) EditComment(ctx context.Context, rs issues.RepoSpec, id uint64,
 		if err != nil {
 			return issues.Comment{}, err
 		}
-		reactions, err := s.reactions(ctx, commentReactions)
+		reactions, err := s.reactions(commentReactions)
 		if err != nil {
 			return issues.Comment{}, err
 		}


### PR DESCRIPTION
See https://developer.github.com/changes/2016-06-07-reactions-api-update/.

Depends on google/go-github#365.

---

For my (future) reference, I tested this out on the following issues with reactions:
- https://github.com/google/go-github/issues/356 - a handful of reactions
- https://github.com/golang/go/issues/15292 - many, many reactions
